### PR TITLE
add option to store queries in ets table

### DIFF
--- a/src/eql.erl
+++ b/src/eql.erl
@@ -1,6 +1,7 @@
 -module(eql).
 -export([ compile/1
         , compile/2
+        , compile/3
         , new_tab/1
         , get_query/2
         ]).
@@ -10,6 +11,12 @@ compile(File) ->
         {ok, Source} -> eql_compiler:compile(Source);
         Error        -> Error
     end.
+
+compile(Tab, File, []) ->
+    compile(Tab, File);
+compile(Tab, File, [flush]) ->
+    ets:delete_all_objects(Tab),
+    compile(Tab, File).
 
 compile(Tab, File) ->
     case compile(File) of

--- a/src/eql.erl
+++ b/src/eql.erl
@@ -1,5 +1,7 @@
 -module(eql).
 -export([ compile/1
+        , compile/2
+        , new_tab/1
         , get_query/2
         ]).
 
@@ -9,6 +11,26 @@ compile(File) ->
         Error        -> Error
     end.
 
+compile(Tab, File) ->
+    case compile(File) of
+        {ok, Queries} ->
+            ets:insert(Tab, Queries),
+            ok;
+        Error ->
+            Error
+    end.
+
+new_tab(Name) ->
+    ets:new(Name, [named_table, set, {read_concurrency, true}]).
+
+get_query(Name, Tid) when is_reference(Tid)
+                        ; is_atom(Tid) ->
+    case ets:lookup(Tid, Name) of
+        [] ->
+            not_found;
+        [{_, Query}] ->
+            Query
+    end;
 get_query(Name, Proplist) ->
     case lists:keyfind(Name, 1, Proplist) of
         {Name, Value} -> Value;


### PR DESCRIPTION
A quick version based on what I did to use eql in https://github.com/SpaceTime-IoT/erleans/blob/jch/src/erleans_pgsql_blob_provider.erl

Aldo debated just using `application:get/set_env` since it is backed by an ets table and generating modules or adding the queries as functions to a module -- could be kind of cool but probably not worth the trouble.