### PR TITLE
support namespacing queries in ets by filename

### DIFF
--- a/src/eql.erl
+++ b/src/eql.erl
@@ -13,22 +13,32 @@
 -type query() :: binary() | [binary() | atom()].
 -type query_list() :: [{atom(), query()}].
 
+-type compile_opt() :: flush | %% delete all (or for this namespace) queries first
+                       namespace. %% store queries in ets table keyed on a 2-tuple of
+                                  %% the filename as an atom and the name of the query
+
 %% returns a list of
 -spec compile(file:filename_all()) -> {ok, query_list()} | any().
 compile(File) ->
     eql_parse:file(File).
 
-compile(Tab, File, []) ->
-    compile(Tab, File);
-compile(Tab, File, [flush]) ->
-    ets:delete_all_objects(Tab),
-    compile(Tab, File).
-
 compile(Tab, File) ->
+    compile(Tab, File, []).
+
+-spec compile(atom() | ets:tid(), file:filename_all(), [compile_opt()]) -> ok | any().
+compile(Tab, File, Opts) ->
+    maybe_flush(Tab, File, Opts),
     case compile(File) of
         {ok, Queries} when is_list(Queries) ->
-            ets:insert(Tab, Queries),
-            ok;
+            case proplists:get_value(namespace, Opts, false) of
+                true ->
+                    Namespace = file_to_namespace(File),
+                    true = ets:insert(Tab, [{{Namespace, Name}, Query} || {Name, Query} <- Queries]),
+                    ok;
+                false ->
+                    true = ets:insert(Tab, Queries),
+                    ok
+            end;
         Error ->
             Error
     end.
@@ -62,4 +72,24 @@ get_query(Name, Proplist) ->
     case lists:keyfind(Name, 1, Proplist) of
         {Name, Value} -> {ok, Value};
         false -> undefined
+    end.
+
+%% internal functions
+
+-spec file_to_namespace(file:filename_all()) -> atom().
+file_to_namespace(File) ->
+    list_to_atom(filename:rootname(filename:basename(File))).
+
+maybe_flush(Tab, File, Opts) ->
+    case proplists:get_value(flush, Opts, false) of
+        true ->
+            case proplists:get_value(namespace, Opts, false) of
+                true ->
+                    Namespace = file_to_namespace(File),
+                    ets:match_delete(Tab, {{Namespace, '_'}, '_'});
+                false ->
+                    ets:delete_all_objects(Tab)
+            end;
+        false ->
+            ok
     end.

--- a/test/eql_compiler_tests.erl
+++ b/test/eql_compiler_tests.erl
@@ -6,6 +6,7 @@ eql_compiler_test_() -> {setup,
     [ fun test_compile/0
     , fun test_named_params/0
     , fun test_file/0
+    , fun test_file_namespace/0
     ]}.
 
 start() -> ok.
@@ -36,6 +37,11 @@ test_file() ->
     ?assertMatch([ {get_all_users, <<"SELECT * FROM users">>}
                  , {get_user_by_id, <<"SELECT * FROM users WHERE id = ?">>}
                  ], Queries).
+
+test_file_namespace() ->
+    eql:new_tab(test_tab),
+    eql:compile(test_tab, from_examples_dir("queries.sql"), [namespace]),
+    ?assertEqual({ok, <<"SELECT * FROM users">>}, eql:get_query({queries, get_all_users}, test_tab)).
 
 %%
 %% Helpers


### PR DESCRIPTION
Adds support to store queries with a "namespace" based on the name of the file they were loaded from:

```
eql:compile(test_tab, from_examples_dir("queries.sql"), [namespace]),
eql:get_query({queries, get_all_users}, test_tab)
```

What do you think? I realized I would end up with dozens of ets tables with like 5 queries each if I used different ets to separate queries with the same name, which is a waste of resources.