### PR TITLE
break named parameters at periods

### DIFF
--- a/examples/queries.sql
+++ b/examples/queries.sql
@@ -9,3 +9,8 @@ FROM users
 -- name: get_user_by_id
 SELECT * FROM
 users WHERE id = ?
+
+-- another comment
+-- name: get_all_schema_users
+SELECT *
+FROM :schema.users

--- a/src/eql_parse.erl
+++ b/src/eql_parse.erl
@@ -86,7 +86,7 @@ lists:map(fun({param, P}) -> binary_to_atom(iolist_to_binary(P), utf8);
 
 -spec 'param'(input(), index()) -> parse_result().
 'param'(Input, Index) ->
-  p(Input, Index, 'param', fun(I,D) -> (p_seq([p_string(<<":">>), p_label('key', p_one_or_more(p_seq([p_not(p_string(<<"\s">>)), p_not(fun 'crlf'/2), p_anything()])))]))(I,D) end, fun(Node, _Idx) ->proplists:get_value(key, Node) end).
+  p(Input, Index, 'param', fun(I,D) -> (p_seq([p_string(<<":">>), p_label('key', p_one_or_more(p_seq([p_not(p_string(<<"\s">>)), p_not(p_string(<<".">>)), p_not(fun 'crlf'/2), p_anything()])))]))(I,D) end, fun(Node, _Idx) ->proplists:get_value(key, Node) end).
 
 -spec 'comment_marker'(input(), index()) -> parse_result().
 'comment_marker'(Input, Index) ->

--- a/src/eql_parse.peg
+++ b/src/eql_parse.peg
@@ -46,7 +46,7 @@ lists:map(fun({param, P}) -> binary_to_atom(iolist_to_binary(P), utf8);
 
 substatement <- (!':' !comment_marker .)* ~;
 
-param <- ":" key:(!' ' !crlf .)+ `proplists:get_value(key, Node)`;
+param <- ":" key:([a-zA-Z0-9_-])+ `proplists:get_value(key, Node)`;
 
 comment_marker <- "--" ~;
 space <- [ \t\n\s\r]* ~;

--- a/test/eql_compiler_tests.erl
+++ b/test/eql_compiler_tests.erl
@@ -7,6 +7,7 @@ eql_compiler_test_() -> {setup,
     , fun test_named_params/0
     , fun test_file/0
     , fun test_file_namespace/0
+    , fun test_file_named_params/0
     ]}.
 
 start() -> ok.
@@ -36,12 +37,18 @@ test_file() ->
     {ok, Queries} = eql_parse:parse(Source),
     ?assertMatch([ {get_all_users, <<"SELECT * FROM users">>}
                  , {get_user_by_id, <<"SELECT * FROM users WHERE id = ?">>}
-                 ], Queries).
+                 , {get_all_schema_users, [<<"SELECT * FROM ">>, schema, <<".users">>]}], Queries).
 
 test_file_namespace() ->
     eql:new_tab(test_tab),
     eql:compile(test_tab, from_examples_dir("queries.sql"), [namespace]),
     ?assertEqual({ok, <<"SELECT * FROM users">>}, eql:get_query({queries, get_all_users}, test_tab)).
+
+test_file_named_params() ->
+    eql:new_tab(test_tab2),
+    eql:compile(test_tab2, from_examples_dir("queries.sql")),
+    ?assertEqual({ok, [<<"SELECT * FROM ">>, <<"public">>, <<".users">>]},
+                 eql:get_query(get_all_schema_users, test_tab2, [{schema, <<"public">>}])).
 
 %%
 %% Helpers


### PR DESCRIPTION
This is fairly specific to my use, so I'm not sure if it is acceptable. Basically I'd like name parameters to not only break on spaces but also periods and really open to any punctuation being part of the characters that breaks a named parameter.

Thoughts?