### PR TITLE
feature: add load/3 to eql_config

### DIFF
--- a/examples/dynamic.conf.in
+++ b/examples/dynamic.conf.in
@@ -1,0 +1,7 @@
+-- Example to test the new eql_config:load/3 command
+-- name: dynamic_config
+[
+    {"a",":value_a"},
+    {"b",":value_b"},
+    {"c",":value_c"}
+].

--- a/examples/queries.sql
+++ b/examples/queries.sql
@@ -17,3 +17,4 @@ FROM :schema.users
 --
 -- name: accept_type_casts
 select '[{"a":"foo"},{"b":"bar"},{"c":"baz"}]'::json->2
+

--- a/src/eql.erl
+++ b/src/eql.erl
@@ -51,11 +51,14 @@ new_tab(Name) ->
 get_query(Name, TidOrList, Params) ->
     case get_query(Name, TidOrList) of
         {ok, Query} ->
-            {ok, lists:map(fun(Key) when is_atom(Key) ->
+            case is_bitstring(Query) of
+                true -> {ok,Query};
+                false -> {ok, lists:map(fun(Key) when is_atom(Key) ->
                                proplists:get_value(Key, Params);
                               (S) ->
                                S
-                           end, Query)};
+                           end, Query)}
+            end;
         Other ->
             Other
     end.

--- a/src/eql_config.erl
+++ b/src/eql_config.erl
@@ -1,8 +1,25 @@
 -module(eql_config).
--export([load/2]).
+
+-export([load/2, load/3]).
 
 load(Env, Config) ->
-    parse(scan(proplists:get_value(Env, Config))).
+    case eql:get_query(Env,Config) of
+        {ok,ResolvedConfig} ->
+        case is_bitstring(ResolvedConfig) of
+            true -> parse(scan(ResolvedConfig));
+            false -> {error,"Missing variables"}
+        end;
+        {error,Error} -> {error,Error}
+    end.
+
+load(Env, Config,Variables) ->
+    case eql:get_query(Env,Config,Variables) of
+
+        {ok,ResolvedConfig} ->
+            ScanResult = scan(ResolvedConfig),
+            parse(ScanResult);
+        {error,Error} -> {error,Error}
+    end.
 
 scan(undefined) ->
     undefined;


### PR DESCRIPTION
The eql_config module was augmented with a load-function which can inject variables.

README.md file was updated to reflect the new options.

A unit-test was added ( see examples/dynamic.conf.in ).